### PR TITLE
Add warning for IL2CPP builds to Unity overview

### DIFF
--- a/using-yarnspinner-with-unity/overview.md
+++ b/using-yarnspinner-with-unity/overview.md
@@ -7,3 +7,7 @@ In this section, you’ll learn how to install, set up, and work with Yarn Spinn
 {% hint style="info" %}
 Yarn Spinner for Unity works with Unity version 2019.4 and later.
 {% endhint %}
+
+{% hint style="danger" %}
+Use IL2CPP? When building your project, set IL2CPP Code Generation to **Faster (smaller) builds** to avoid crashes. See [this issue](https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/163) for more information.
+{% endhint %}


### PR DESCRIPTION
I've seen plenty of people running into problems with IL2CPP builds (myself included 😅), so I think it's worth mentioning the fix in the documentation to save people from having to ask in the Discord or go spelunking through GitHub to find the related issue (which is actually pretty tough as the title of the issue only refers to WebGL!).