### PR TITLE
update some instructions for workflow changes in YarnSpinner-Godot 0.2.0

### DIFF
--- a/docs/beginners-guide/using-a-game-engine/yarn-spinner-for-godot.md
+++ b/docs/beginners-guide/using-a-game-engine/yarn-spinner-for-godot.md
@@ -75,25 +75,19 @@ Your Scene dock will look like this showing a node hierarchy that's entirely bas
 You could also instantiate the `DefaultDialogueSystem.tscn` into your scene at a lower part of the hierarchy, instead of the root node, to display dialogue using the provided default UI, instead.
 {% endhint %}
 
-Next, create a new Yarn Project by right-clicking in the FileSystem dock, and choosing Resource...:
+Next, create a new Yarn Project using the menu Tools > YarnSpinner >Create Yarn Project:
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-17 at 3.23.05 pm.png" alt="" width="563"><figcaption><p>Creating a new Resource in the FileSystem dock.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-17 at 3.23.05 pm.png" alt="" width="563"><figcaption><p>Opening the menu to create a new .yarnproject file.</p></figcaption></figure>
 
-Then filter to the `YarnProject` resource type, and click the Create button:
+Then choose a directory to save your new YarnProject in. For example, you can save it to the root of your project. Name the new Yarn Project `FirstProject.yarnproject`:
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-17 at 3.23.14 pm.png" alt="" width="563"><figcaption><p>Creating a new YarnProject resource.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-17 at 3.23.14 pm.png" alt="" width="563"><figcaption><p>Selecting a location to save your .yarnproject file.</p></figcaption></figure>
 
-Name the new Yarn Project `FirstProject.tres`.&#x20;
+Next, create a new Yarn script (a file with a `.yarn` extension) by using the menu Tools > YarnSpinner >Create Yarn Script. In the resulting "Create a new Yarn Script" window, set the File name to `MyStory.yarn`, and click the Save button::
 
-Next, create a new Yarn script (a file with a `.yarn` extension) by right-clicking in the FileSystem dock, and choosing New TextFile:
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-18 at 10.12.52 am.png" alt="" width="413"><figcaption><p>Opening the Create Yarn Script window</p></figcaption></figure>
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-18 at 10.12.52 am.png" alt="" width="413"><figcaption><p>Creating a new TextFile, in order to add a Yarn script.</p></figcaption></figure>
-
-In the resulting New Text File... window, select All Files (\*) from the dropdown in the corner, set the File name to `MyStory.yarn`, and click the Save button:
-
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-18 at 10.19.15 am.png" alt="" width="563"><figcaption><p>Naming the file for a new Yarn script.</p></figcaption></figure>
-
-It may take a moment, but Godot will import your new `.yarn` file, and it will appear in the FileSystem dock. When it's appeared, double-click on the Yarn Project, `FirstProject.tres` in the FileSystem dock and look to the Inspector, making sure that `res://MyStory.yarn` is in the list of Source Scripts, which are the Yarn scripts that compromise the new project:
+It may take a moment, but Godot will import your new `.yarn` file, and it will appear in the FileSystem dock. When it's appeared, double-click on the Yarn Project, `FirstProject.yarnproject` in the FileSystem dock and look to the Inspector, making sure that `res://MyStory.yarn` is in the list of Source Scripts, which are the Yarn scripts that compromise the new project:
 
 <figure><img src="../../.gitbook/assets/Screenshot 2023-10-18 at 10.25.13 am.png" alt="" width="563"><figcaption><p>The Yarn Project, with the Yarn script identified as a Source Script.</p></figcaption></figure>
 
@@ -129,7 +123,7 @@ Narrator: Someone read the Beginner's Guide!
 
 </details>
 
-Select the the `DialogueRunner` node in the Scene dock, and look to the Inspector. Assign the Yarn Project you created to the `DialogueRunner` by dragging the `FirstProject.tres` Yarn Project from the FileSystem dock into the Yarn Project slot of the Inspector:
+Select the `DialogueRunner` node in the Scene dock, and look to the Inspector. Assign the Yarn Project you created to the `DialogueRunner` by dragging the `FirstProject.tres` Yarn Project from the FileSystem dock into the Yarn Project slot of the Inspector:
 
 <figure><img src="../../.gitbook/assets/Screenshot 2023-10-18 at 10.34.38 am.png" alt="" width="563"><figcaption><p>The new Yarn Project resource assigned as the Yarn Project for the <code>DialogueRunner</code>.</p></figcaption></figure>
 


### PR DESCRIPTION
Starting on the changes for updating the beginner's guide for the changes in YarnSpinner-Godot 0.2.0

- [x] Instructions for creating `.yarnproject`s and `.yarn` scripts
- [x]  Update screenshots - I might be able to replicate the style of the existing screenshots with my spare Mac machine. The screenshots that need to be updated have their description updated in this branch. Edit: attached screenshots, but I didn't update the links in this branch yet. If you'd like me to let me know.
- [ ] Address any questions or feedback 

Merge after https://github.com/YarnSpinnerTool/YarnSpinner-Godot/pull/28

Let me know any requests to help with further doc updates for these changes -whether updating some other doc files or just answering questions about how the plugin works.  Thanks