### PR TITLE
add warning for older beginner's guide

### DIFF
--- a/docs/beginners-guide/using-a-game-engine/yarn-spinner-for-godot.md
+++ b/docs/beginners-guide/using-a-game-engine/yarn-spinner-for-godot.md
@@ -18,6 +18,8 @@ layout:
 # Yarn Spinner for Godot
 
 {% hint style="danger" %}
+This version of the Yarn Spinner for Godot Beginner's guide was written for plugin version 0.1.5. 
+If you are using a newer version of the plugin, please reference a newer version of the documentation.
 Yarn Spinner for Godot is a Yarn Labs project. It is not fully, or officially supported, and may break, or change at any time.
 {% endhint %}
 


### PR DESCRIPTION
Add warning to the 2.3 beginner's guide that explains which version of the Godot plugin it was written for