### PR TITLE
Update quick-start.md: Replaced Unity Quickstart dead link and "Dialogue System" -> "Dialogue Runner"

### DIFF
--- a/docs/using-yarnspinner-with-unity/quick-start.md
+++ b/docs/using-yarnspinner-with-unity/quick-start.md
@@ -8,9 +8,9 @@ Want to use Yarn Spinner in a new scene right away? Follow these steps.
 
 ### Setting Up A Demo Scene
 
-1. **Create a new empty Unity project**, by following [the instructions in the Unity manual](https://docs.unity3d.com/Manual/GettingStarted.html).
+1. **Create a new empty Unity project**, by following [the instructions in the Unity manual](https://docs.unity3d.com/Manual/QuickstartGuides.html).
 2. **Install Yarn Spinner into the project**, by following the instructions in [installation-and-setup.md](installation-and-setup.md "mention").
-3. **Add a Dialogue System to the scene:**, by opening the GameObject menu and choosing Yarn Spinner -> Dialogue System.
+3. **Add a Dialogue System to the scene:**, by opening the GameObject menu and choosing Yarn Spinner -> Dialogue Runner.
 4. **Create a new** [**Yarn script**](importing-yarn-files/yarn-scripts.md), by opening the Assets menu and choosing Create -> Yarn Spinner -> Yarn Script. Name the new file `HelloYarn`.&#x20;
 5. **Open the new Yarn script** by double-clicking it.
    1. Select all of the text in the file, and delete it.


### PR DESCRIPTION
Replaced the Unity starting guide dead link and renamed Dialogue System to Dialogue Runner as "Dialogue System" does not exist in the Unity menu based on trying to set it up myself.